### PR TITLE
(rp) - Added the splitting option on the address for organisms - refs #2809

### DIFF
--- a/apps/rp/modules/contact/actions/csv.php
+++ b/apps/rp/modules/contact/actions/csv.php
@@ -173,7 +173,7 @@
         $addr = explode("\r\n", $this->lines[$key]['organism_address']);
         for ( $i = 0 ; $i < count($addr) ; $i++ )
         {
-          $j = $i>2?3:$i+1;
+          $j = $i > 2 ? 3 : $i + 1;
           $this->lines[$key]['organism_address'.$j] = !isset($this->lines[$key]['organism_address'.$j])
             ? $addr[$i]
             : $this->lines[$key]['organism_address'.$j]."\r\n".$addr[$i];

--- a/apps/rp/modules/contact/actions/csv.php
+++ b/apps/rp/modules/contact/actions/csv.php
@@ -168,6 +168,17 @@
             : $this->lines[$key]['address'.$j]."\r\n".$addr[$i];
         }
         unset($this->lines[$key]['address']);
+        
+        unset($params['field']['organism_address']);
+        $addr = explode("\r\n", $this->lines[$key]['organism_address']);
+        for ( $i = 0 ; $i < count($addr) ; $i++ )
+        {
+          $j = $i>2?3:$i+1;
+          $this->lines[$key]['organism_address'.$j] = !isset($this->lines[$key]['organism_address'.$j])
+            ? $addr[$i]
+            : $this->lines[$key]['organism_address'.$j]."\r\n".$addr[$i];
+        }
+        unset($this->lines[$key]['organism_address']);
       }
       
       // removing professionals objects to get a flat array

--- a/lib/form/doctrine/OptionCsvForm.class.php
+++ b/lib/form/doctrine/OptionCsvForm.class.php
@@ -138,6 +138,9 @@ class OptionCsvForm extends BaseOptionCsvForm
   	  '__Professionals__Groups__name' => "Professionals groups",
   	  'professional_important' => 'Close contact / Important organism',
     	'organism_address'    => 'Address',
+        'organism_address1'   => 'Address',
+    	  'organism_address2'   => 'Address',
+    	  'organism_address3'   => 'Address',        
 	    'organism_postalcode' => 'Postalcode',
   	  'organism_city'       => 'City',
     	'organism_country'    => 'Country',
@@ -177,6 +180,12 @@ class OptionCsvForm extends BaseOptionCsvForm
       $options['field'][] = 'address2';
       $options['field'][] = 'address3';
       $options['field'] = self::orderData($options['field']);
+      if ( ($i = array_search('organism_address', $options['field'])) !== false )
+        unset($options['field'][$i]);
+      $options['field'][] = 'organism_address1';
+      $options['field'][] = 'organism_address2';
+      $options['field'][] = 'organism_address3';
+      $options['field'] = self::orderData($options['field']);
     }
 
     return $options;
@@ -199,6 +208,9 @@ class OptionCsvForm extends BaseOptionCsvForm
       {
         $arr = array(
           'organism_address'    => 'address',
+          'organism_address1'   => 'address1',
+          'organism_address2'   => 'address2',
+          'organism_address3'   => 'address3',
           'organism_postalcode' => 'postalcode',
           'organism_city'       => 'city',
           'organism_country'    => 'country',
@@ -206,8 +218,8 @@ class OptionCsvForm extends BaseOptionCsvForm
         );
         foreach ( $arr as $origin => $target )
         {
-          $contact[$target] = $contact[$origin];
-          unset($contact[$origin]);
+            $contact[$target] = $contact[$origin];
+            //unset($contact[$origin]);
         }
       }
 
@@ -231,7 +243,7 @@ class OptionCsvForm extends BaseOptionCsvForm
         $contact['phonename']    = 'Professional';
         $contact['phonenumber']  = $contact['professional_number'];
       }
-      unset($contact['organism_phonename'], $contact['organism_phonenumber'], $contact['professional_number']);
+      //unset($contact['organism_phonename'], $contact['organism_phonenumber'], $contact['professional_number']);
 
       return $contact;
   }


### PR DESCRIPTION
in the csv contact extraction file

Fixed shifted headers with the professionnal option. The data were removed but not the headers.
Fixed a bug where splitting and professionnal options were selected. Organism address did not replace contact address.