### PR TITLE
(rp) - The phone type was not properly saved when creating a contact - refs #1374

### DIFF
--- a/lib/widget/liWidgetFormDoctrineJQueryAutocompleterGuide.class.php
+++ b/lib/widget/liWidgetFormDoctrineJQueryAutocompleterGuide.class.php
@@ -69,13 +69,9 @@ class liWidgetFormDoctrineJQueryAutocompleterGuide extends liWidgetFormDoctrineJ
         return parsed;
       }
     }, %s))
-    .result(function(event, data) { jQuery(input).val(data[1]); });
-    
-    jQuery(input).closest('form').submit(function(){
-      if ( jQuery(input).val() != jQuery(autocomplete).val() )
-      {
+    .result(function(event, data) { jQuery(input).val(data[1]); })
+    .change(function() {
         jQuery(input).val(jQuery(autocomplete).val());
-      }
     });
   });
 </script>


### PR DESCRIPTION
The form was submitted before the autocomplete js could catch it and copy the value to the proper input.