### PR TITLE
(event) - Fixed a bug that allowed multiple instances of Garbage collector to launch - refs #3363

### DIFF
--- a/apps/event/config/eventConfiguration.class.php
+++ b/apps/event/config/eventConfiguration.class.php
@@ -112,6 +112,15 @@ class eventConfiguration extends sfApplicationConfiguration
       {
         foreach ( array('showTickets', 'showSpectators', 'statsFillingData',) as $action )
         {
+          // Update lock time for very long processes
+          if ( file_exists($lockfile) ) {
+            touch($lockfile);
+          }
+          else {
+            $this->stdout($section, 'No lock file. Stopping...', 'ERROR');
+            return $this;
+          }            
+          
           $context = sfContext::getInstance();
           // this is a workaround for some cases where the user is lost between actions ??...
           if ( !$context->getUser()->getId() )


### PR DESCRIPTION
When a process ran for more than 12 hours, another one was launched regardless of the status of the previous one.

Merge to Master as well.